### PR TITLE
Distinguish between dotfile repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Your own dotfiles repo should be private, since it could contain secret informat
 3. [Duplicate the repo](https://docs.github.com/en/repositories/creating-and-managing-repositories/duplicating-a-repository):
 ```
 git clone --bare git@github.com:ClipboardHealth/dotfiles.git
-cd dotfiles
-git push --mirror git@github.com:YOUR_USERNAME/dotfiles.git
+cd dotfiles.git
+git push --mirror git@github.com:YOUR_USERNAME/YOUR_DOTFILES_REPO.git
 cd .. && rm -rf dotfiles.git
-git clone git@github.com:YOUR_USERNAME/dotfiles.git
+git clone git@github.com:YOUR_USERNAME/YOUR_DOTFILES_REPO.git
 code dotfiles
 ```
 ## Add your SSH keys


### PR DESCRIPTION
The instructions could not be copied and pasted line by line.

The bare cloned repo shows up as `dotfiles.git` instead of `dotfiles`, I changed the command to `cd dotfiles.git` so it can be copy and pasted.

Also, it's confusing when both the source repository and the user's personal repo are named `dotfiles.git`. I changed the command to mirror repo to make this clear.